### PR TITLE
No need for two ReactFlowProvider

### DIFF
--- a/lib/NodeGraphEditor.tsx
+++ b/lib/NodeGraphEditor.tsx
@@ -73,11 +73,9 @@ export const ExampleNodeGraphEditor = forwardRef<
   const config = useBuildGraphConfig(_config)
   return (
     <GraphConfigProvider defaultConfig={config}>
-      <ReactFlowProvider>
-        <NodeGraphEditor ref={ref} defaultNodes={nodes} defaultEdges={edges}>
-          <Background color="#52525b" variant={BackgroundVariant.Dots} />
-        </NodeGraphEditor>
-      </ReactFlowProvider>
+      <NodeGraphEditor ref={ref} defaultNodes={nodes} defaultEdges={edges}>
+        <Background color="#52525b" variant={BackgroundVariant.Dots} />
+      </NodeGraphEditor>
     </GraphConfigProvider>
   )
 })

--- a/lib/NodeGraphEditorCustomInput.stories.tsx
+++ b/lib/NodeGraphEditorCustomInput.stories.tsx
@@ -6,7 +6,6 @@ import {
   BackgroundVariant,
   Edge,
   Node,
-  ReactFlowProvider,
 } from '@xyflow/react'
 import { useBuildGraphConfig } from './hooks/config.ts'
 import { NodeInputField } from './components/NodeInputField.tsx'
@@ -73,11 +72,9 @@ const meta = {
     )
     return (
       <GraphConfigProvider defaultConfig={config}>
-        <ReactFlowProvider>
-          <NodeGraphEditor defaultNodes={nodes} defaultEdges={edges}>
-            <Background color="#52525b" variant={BackgroundVariant.Dots} />
-          </NodeGraphEditor>
-        </ReactFlowProvider>
+        <NodeGraphEditor defaultNodes={nodes} defaultEdges={edges}>
+          <Background color="#52525b" variant={BackgroundVariant.Dots} />
+        </NodeGraphEditor>
       </GraphConfigProvider>
     )
   },

--- a/lib/NodeGraphEditorCustomNode.stories.tsx
+++ b/lib/NodeGraphEditorCustomNode.stories.tsx
@@ -9,7 +9,6 @@ import {
   Edge,
   Node,
   Position,
-  ReactFlowProvider,
 } from '@xyflow/react'
 import { NodeContainer } from './components/NodeContainer'
 import { useFocusBlur } from './hooks/focus'
@@ -71,11 +70,9 @@ const meta = {
     }, [])
     return (
       <GraphConfigProvider defaultConfig={config}>
-        <ReactFlowProvider>
-          <NodeGraphEditor defaultNodes={nodes} defaultEdges={edges}>
-            <Background color="#52525b" variant={BackgroundVariant.Dots} />
-          </NodeGraphEditor>
-        </ReactFlowProvider>
+        <NodeGraphEditor defaultNodes={nodes} defaultEdges={edges}>
+          <Background color="#52525b" variant={BackgroundVariant.Dots} />
+        </NodeGraphEditor>
       </GraphConfigProvider>
     )
   },

--- a/lib/NodeGraphEditorInputGroups.stories.tsx
+++ b/lib/NodeGraphEditorInputGroups.stories.tsx
@@ -6,7 +6,6 @@ import {
   BackgroundVariant,
   Edge,
   Node,
-  ReactFlowProvider,
 } from '@xyflow/react'
 import { useBuildGraphConfig } from './hooks/config.ts'
 import { InputProps } from './config.ts'
@@ -202,11 +201,9 @@ const meta = {
     )
     return (
       <GraphConfigProvider defaultConfig={config}>
-        <ReactFlowProvider>
-          <NodeGraphEditor defaultNodes={nodes} defaultEdges={edges}>
-            <Background color="#52525b" variant={BackgroundVariant.Dots} />
-          </NodeGraphEditor>
-        </ReactFlowProvider>
+        <NodeGraphEditor defaultNodes={nodes} defaultEdges={edges}>
+          <Background color="#52525b" variant={BackgroundVariant.Dots} />
+        </NodeGraphEditor>
       </GraphConfigProvider>
     )
   },


### PR DESCRIPTION
NodeGraphEditor has a ReactFlowProvider inside it, so no reason to surround NodeGraphEditor with another.